### PR TITLE
Enables set configuration

### DIFF
--- a/lib/padrino-grape/extend.rb
+++ b/lib/padrino-grape/extend.rb
@@ -3,7 +3,8 @@
 module PadrinoGrape
 
   module Extend
-
+    include Grape::DSL::Settings
+    
     def root
       @_root ||= File.expand_path('..', __FILE__)
     end
@@ -41,6 +42,10 @@ module PadrinoGrape
 
     def public_folder
       ""
+    end
+
+    def set(key, value)
+      global_setting(key, value)
     end
 
   end


### PR DESCRIPTION
Hi,

I'm working on a SaaS Application using Padrino and Grape; and the integration with padrigno-grape is not working because Grape has changed methods for configurations in this commit: https://github.com/intridea/grape/commit/f8596829325123b5793d8f84b72e0b85ddffc207#diff-71dbcdb11d8a66b687e2598f19ff2395. The result is that Grape can't be mounted in Padrino because mounter.rb sets global configurations at mount moment. 

The  solution is implement the **set** method in padrino-grape/extend.rb with new DSL for set global configurations.
