### PR TITLE
Add methods to Grape::Route to support rake routes

### DIFF
--- a/lib/padrino-grape/extend.rb
+++ b/lib/padrino-grape/extend.rb
@@ -46,13 +46,32 @@ module PadrinoGrape
   end
 
   def self.extended base
+    base.superclass.parent::Route.__send__ :include, ::PadrinoGrape::RouteExtend
     base.__send__ :extend, ::PadrinoGrape::Extend
     base.__send__ :setup_application!
   end
 
   def self.included base
+    base.superclass.parent::Route.__send__ :include, ::PadrinoGrape::RouteExtend
     base.__send__ :extend, ::PadrinoGrape::Extend
     base.__send__ :setup_application!
   end
 
+  module RouteExtend
+    def name
+      @options[:path]
+    end
+
+    def controller
+      @options[:namespace]
+    end
+
+    def request_methods
+      [@options[:method]]
+    end
+
+    def original_path
+      @options[:path]
+    end
+  end
 end


### PR DESCRIPTION
Grape::Route does not have corresponding methods to run properly in
pardino's rake routes task. This commit adds those methods.
